### PR TITLE
Kwyg 15 about+impressum seite erstellen

### DIFF
--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -1,9 +1,14 @@
 import Home from "../pages/home.jsx";
+import Impressum from "../pages/impressum.jsx";
 
 var routes = [
   {
     path: "/",
     component: Home,
+  },
+  {
+    path: "/impressum",
+    component: Impressum,
   },
 ];
 

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Page, Searchbar, List, BlockTitle, Link } from "framework7-react";
+import { Page, Searchbar, List, BlockTitle, Button } from "framework7-react";
 import { MapContainer, TileLayer, useMap, useMapEvents } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import SnappingSheet from "../components/SnappingSheet";
@@ -265,7 +265,13 @@ class Home extends React.Component {
           <BlockTitle>{address}</BlockTitle>
 
           <List></List>
-          <Link href="/impressum">Impressum</Link>
+          <Button
+            round
+            outline
+            href="/impressum"
+            text="Impressum"
+            style={{ width: "fit-content", marginLeft: "50%" }}
+          ></Button>
         </SnappingSheet>
       </Page>
     );

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Page, Searchbar, List, BlockTitle } from "framework7-react";
+import { Page, Searchbar, List, BlockTitle, Link } from "framework7-react";
 import { MapContainer, TileLayer, useMap, useMapEvents } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import SnappingSheet from "../components/SnappingSheet";
@@ -265,6 +265,7 @@ class Home extends React.Component {
           <BlockTitle>{address}</BlockTitle>
 
           <List></List>
+          <Link href="/impressum">Impressum</Link>
         </SnappingSheet>
       </Page>
     );

--- a/src/pages/impressum.jsx
+++ b/src/pages/impressum.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Page, Block, BlockTitle, PageContent, Link } from "framework7-react";
+import { Page, Block, BlockTitle, Link } from "framework7-react";
 
 class Impressum extends React.Component {
   constructor(props) {
@@ -26,59 +26,59 @@ class Impressum extends React.Component {
             Die Anwendung ist open source und kann auf{" "}
             <Link href="https://github.com/DHBW-FN-TIT20/know-where-you-go">GitHub</Link> gefunden werden.
           </p>
-          <p>
-            Die App wird von Studenten der DHBW Friedrichshafen entwickelt:
-            <ul>
-              <li>
-                <Link href="https://github.com/baldur132">Baldur Siegel</Link>
-              </li>
-              <li>
-                <Link href="https://github.com/schuler-henry">Henry Schuler</Link>
-              </li>
-              <li>
-                <Link href="https://github.com/Floqueboque">Florian Herkommer</Link>
-              </li>
-              <li>
-                <Link href="https://github.com/Floskinner">Florian Glaser</Link>
-              </li>
-              <li>
-                <Link href="https://github.com/johannesbrandenburger">Johannes Brandenburger</Link>
-              </li>
-              <li>
-                <Link href="https://github.com/screetox">David Felder</Link>
-              </li>
-              <li>
-                <Link href="https://github.com/lukasbraundev">Lukas Braun</Link>
-              </li>
-              <li>
-                <Link href="https://github.com/PhillippPatzelt">Phillipp Patzelt</Link>
-              </li>
-            </ul>
-          </p>
+          <p>Die App wird von Studenten der DHBW Friedrichshafen entwickelt:</p>
+          <ul>
+            <li>
+              <Link href="https://github.com/baldur132">Baldur Siegel</Link>
+            </li>
+            <li>
+              <Link href="https://github.com/schuler-henry">Henry Schuler</Link>
+            </li>
+            <li>
+              <Link href="https://github.com/Floqueboque">Florian Herkommer</Link>
+            </li>
+            <li>
+              <Link href="https://github.com/Floskinner">Florian Glaser</Link>
+            </li>
+            <li>
+              <Link href="https://github.com/johannesbrandenburger">Johannes Brandenburger</Link>
+            </li>
+            <li>
+              <Link href="https://github.com/screetox">David Felder</Link>
+            </li>
+            <li>
+              <Link href="https://github.com/lukasbraundev">Lukas Braun</Link>
+            </li>
+            <li>
+              <Link href="https://github.com/PhillippPatzelt">Phillipp Patzelt</Link>
+            </li>
+          </ul>
         </Block>
-        <PageContent>
-          <BlockTitle>
-            <h1>Impressum</h1>
-          </BlockTitle>
-          <BlockTitle>
-            <h2>Kontakt</h2>
-          </BlockTitle>
-          <Block strong>
-            <p>Angaben gemäß § 5 TMG</p>
-            <p>
-              Florian Glaser<br></br>
-            </p>
-            <p>
-              Fallenbrunnen 2<br></br>
-              88045 Friedrichshafen<br></br>
-              Telefon: 49-123456789
-            </p>
-            E-Mail:{" "}
-            <a href="mailto: glaser.florian-it20@it.dhbw-ravensburg.de">glaser.florian-it20@it.dhbw-ravensburg.de</a>
-          </Block>
-          <BlockTitle>Haftungsausschluss: </BlockTitle>
-          <BlockTitle>Haftung für Inhalte</BlockTitle>
-          <Block>
+        <BlockTitle>
+          <h1>Impressum</h1>
+        </BlockTitle>
+        <BlockTitle>
+          <h2>Kontakt</h2>
+        </BlockTitle>
+        <Block strong>
+          <p>Angaben gemäß § 5 TMG</p>
+          <p>
+            Florian Glaser<br></br>
+          </p>
+          <p>
+            Fallenbrunnen 2<br></br>
+            88045 Friedrichshafen<br></br>
+            Telefon: 49-123456789
+          </p>
+          E-Mail:{" "}
+          <a href="mailto: glaser.florian-it20@it.dhbw-ravensburg.de">glaser.florian-it20@it.dhbw-ravensburg.de</a>
+        </Block>
+        <BlockTitle>
+          <h2>Haftungsausschluss:</h2>
+        </BlockTitle>
+        <Block strong>
+          <h3>Haftung für Inhalte</h3>
+          <p>
             Die Inhalte unserer Seiten wurden mit größter Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und
             Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen. Als Diensteanbieter sind wir gemäß § 7
             Abs.1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis
@@ -88,9 +88,9 @@ class Impressum extends React.Component {
             bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer
             konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese
             Inhalte umgehend entfernen.
-          </Block>
-          <BlockTitle>Haftung für Links</BlockTitle>
-          <Block>
+          </p>
+          <h3>Haftung für Links</h3>
+          <p>
             Unser Angebot enthält Links zu externen Webseiten Dritter, auf deren Inhalte wir keinen Einfluss haben.
             Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten
             Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten
@@ -98,9 +98,9 @@ class Impressum extends React.Component {
             Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist
             jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von
             Rechtsverletzungen werden wir derartige Links umgehend entfernen.
-          </Block>
-          <BlockTitle>Urheberrecht</BlockTitle>
-          <Block>
+          </p>
+          <h3>Urheberrecht</h3>
+          <p>
             Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen
             Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der
             Grenzen des Urheberrechtes bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers.
@@ -109,15 +109,15 @@ class Impressum extends React.Component {
             Insbesondere werden Inhalte Dritter als solche gekennzeichnet. Sollten Sie trotzdem auf eine
             Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von
             Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.
-          </Block>
-          <Block>
-            Website Impressum erstellt durch{" "}
-            <Link href="https://www.impressum-generator.de">impressum-generator.de</Link> von der{" "}
-            <Link href="https://www.kanzlei-hasselbach.de/" rel="nofollow">
-              Kanzlei Hasselbach
-            </Link>
-          </Block>
-        </PageContent>
+          </p>
+        </Block>
+        <Block>
+          Website Impressum erstellt durch <Link href="https://www.impressum-generator.de">impressum-generator.de</Link>{" "}
+          von der{" "}
+          <Link href="https://www.kanzlei-hasselbach.de/" rel="nofollow">
+            Kanzlei Hasselbach
+          </Link>
+        </Block>
       </Page>
     );
   }

--- a/src/pages/impressum.jsx
+++ b/src/pages/impressum.jsx
@@ -9,17 +9,70 @@ class Impressum extends React.Component {
   render() {
     return (
       <Page name="Impressum">
+        <Link back iconOnly iconF7="arrow_left"></Link>
+        <BlockTitle>
+          <h1>About Know-Where-You-Go</h1>
+        </BlockTitle>
+        <Block strong>
+          <p>
+            {" "}
+            Know-Where-You-Go ist eine Webanwendung, die Ihnen hilft, herauszufinden, wo Sie sind und wohin Sie gehen.
+          </p>
+          <p>
+            Es basiert auf dem <Link href="https://www.openstreetmap.org/">OpenStreetMap-Projekt</Link> und verwendet
+            die <Link href="https://www.openstreetmap.org/">OpenStreetMap-API</Link>, um die Daten zu erhalten.
+          </p>
+          <p>
+            Die Anwendung ist open source und kann auf{" "}
+            <Link href="https://github.com/DHBW-FN-TIT20/know-where-you-go">GitHub</Link> gefunden werden.
+          </p>
+          <p>
+            Die App wird von Studenten der DHBW Friedrichshafen entwickelt:
+            <ul>
+              <li>
+                <Link href="https://github.com/baldur132">Baldur Siegel</Link>
+              </li>
+              <li>
+                <Link href="https://github.com/schuler-henry">Henry Schuler</Link>
+              </li>
+              <li>
+                <Link href="https://github.com/Floqueboque">Florian Herkommer</Link>
+              </li>
+              <li>
+                <Link href="https://github.com/Floskinner">Florian Glaser</Link>
+              </li>
+              <li>
+                <Link href="https://github.com/johannesbrandenburger">Johannes Brandenburger</Link>
+              </li>
+              <li>
+                <Link href="https://github.com/screetox">David Felder</Link>
+              </li>
+              <li>
+                <Link href="https://github.com/lukasbraundev">Lukas Braun</Link>
+              </li>
+              <li>
+                <Link href="https://github.com/PhillippPatzelt">Phillipp Patzelt</Link>
+              </li>
+            </ul>
+          </p>
+        </Block>
         <PageContent>
-          <Link back iconOnly iconF7="arrow_left"></Link>
-          <BlockTitle>Impressum</BlockTitle>
-          <Block>Angaben gemäß § 5 TMG</Block>
-          <Block>
-            Florian Glaser<br></br>Fallenbrunnen 2<br></br>88045 Friedrichshafen
-          </Block>
-          <BlockTitle>Kontakt</BlockTitle>
-          <Block>
-            Telefon: 49-123456789
-            <br></br>
+          <BlockTitle>
+            <h1>Impressum</h1>
+          </BlockTitle>
+          <BlockTitle>
+            <h2>Kontakt</h2>
+          </BlockTitle>
+          <Block strong>
+            <p>Angaben gemäß § 5 TMG</p>
+            <p>
+              Florian Glaser<br></br>
+            </p>
+            <p>
+              Fallenbrunnen 2<br></br>
+              88045 Friedrichshafen<br></br>
+              Telefon: 49-123456789
+            </p>
             E-Mail:{" "}
             <a href="mailto: glaser.florian-it20@it.dhbw-ravensburg.de">glaser.florian-it20@it.dhbw-ravensburg.de</a>
           </Block>

--- a/src/pages/impressum.jsx
+++ b/src/pages/impressum.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Page, Block, BlockTitle, PageContent, Link } from "framework7-react";
+
+class Impressum extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <Page name="Impressum">
+        <PageContent>
+          <Link back iconOnly iconF7="arrow_left"></Link>
+          <BlockTitle>Impressum</BlockTitle>
+          <Block>Angaben gemäß § 5 TMG</Block>
+          <Block>
+            Florian Glaser<br></br>Fallenbrunnen 2<br></br>88045 Friedrichshafen
+          </Block>
+          <BlockTitle>Kontakt</BlockTitle>
+          <Block>
+            Telefon: 49-123456789
+            <br></br>
+            E-Mail:{" "}
+            <a href="mailto: glaser.florian-it20@it.dhbw-ravensburg.de">glaser.florian-it20@it.dhbw-ravensburg.de</a>
+          </Block>
+          <BlockTitle>Haftungsausschluss: </BlockTitle>
+          <BlockTitle>Haftung für Inhalte</BlockTitle>
+          <Block>
+            Die Inhalte unserer Seiten wurden mit größter Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und
+            Aktualität der Inhalte können wir jedoch keine Gewähr übernehmen. Als Diensteanbieter sind wir gemäß § 7
+            Abs.1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis
+            10 TMG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde
+            Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen.
+            Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen
+            bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer
+            konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese
+            Inhalte umgehend entfernen.
+          </Block>
+          <BlockTitle>Haftung für Links</BlockTitle>
+          <Block>
+            Unser Angebot enthält Links zu externen Webseiten Dritter, auf deren Inhalte wir keinen Einfluss haben.
+            Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten
+            Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten
+            wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum
+            Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist
+            jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von
+            Rechtsverletzungen werden wir derartige Links umgehend entfernen.
+          </Block>
+          <BlockTitle>Urheberrecht</BlockTitle>
+          <Block>
+            Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen
+            Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der
+            Grenzen des Urheberrechtes bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers.
+            Downloads und Kopien dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet. Soweit
+            die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte Dritter beachtet.
+            Insbesondere werden Inhalte Dritter als solche gekennzeichnet. Sollten Sie trotzdem auf eine
+            Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von
+            Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.
+          </Block>
+          <Block>
+            Website Impressum erstellt durch{" "}
+            <Link href="https://www.impressum-generator.de">impressum-generator.de</Link> von der{" "}
+            <Link href="https://www.kanzlei-hasselbach.de/" rel="nofollow">
+              Kanzlei Hasselbach
+            </Link>
+          </Block>
+        </PageContent>
+      </Page>
+    );
+  }
+}
+
+export default Impressum;

--- a/src/pages/impressum.jsx
+++ b/src/pages/impressum.jsx
@@ -112,7 +112,10 @@ class Impressum extends React.Component {
           </p>
         </Block>
         <Block>
-          Website Impressum erstellt durch <Link href="https://www.impressum-generator.de">impressum-generator.de</Link>{" "}
+          {/* // prettier-ignore */}
+          Website Impressum erstellt durch <Link href="https://www.impressum-generator.de">
+            impressum-generator.de
+          </Link>{" "}
           von der{" "}
           <Link href="https://www.kanzlei-hasselbach.de/" rel="nofollow">
             Kanzlei Hasselbach


### PR DESCRIPTION
# Hinzufügen des Impressums / About
Neue Seite für Impressum hinzugefügt. Zum Aufrufen auf den entsprechenden Button klicken:
![image](https://user-images.githubusercontent.com/58706771/208145914-3ef55499-823a-4779-a2ec-db8939ac2b56.png)

Impressum und About schaut wie folgt aus:
![image](https://user-images.githubusercontent.com/58706771/208148277-02746332-f107-4cc9-a370-734aeeb4b473.png)
![image](https://user-images.githubusercontent.com/58706771/208148326-ada6a146-9d0e-4cf2-8d7c-0b45120dace6.png)


Closes #20 