### PR TITLE
KWYG-30 Automatisches deployen verbessern

### DIFF
--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -90,6 +90,10 @@ jobs:
         ls -la
         ls -la www
 
+    - name: Add CNAME
+      run: |
+        echo "know-where-you-go.de" > CNAME
+
     - name: Deploy 🚀
       uses: crazy-max/ghaction-github-pages@v3
       with:

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -5,8 +5,6 @@ name: New Release
 
 on:
   push:
-    branches:
-      - "main"
     tags:
       - v*.*.*
 


### PR DESCRIPTION
Closes #39 

- Triggert das Event nur, wenn ein Tag im passenden Format hinzugefügt wird `v*.*.*`
- Triggert nicht mehr, wenn einfach auf `main` gepusht wird
- Automatisches Hinzufügen von `CNAME` damit https://know-where-you-go.de weiterhin funktioniert 